### PR TITLE
Includes instructions for how to check nix install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
 # Agent
-
 The Agent is a conversational assistant designed to help team members in organizations establish a shared information context and work more efficiently together. The agent is built using Python and the Langchain library.
+## Using `just`
+`just shell`
+## Manually
+0. Clone this repo
+1. Install [nix](https://nixos.org/download.html#nix-install-macos)
+To test installation:
+1.1 run `echo $PATH` and ensure `{...}/.nix-profile/bin` is the first element; if not, try `export PATH=$HOME/.nix-profile/bin:$PATH`
+1.2 create `shell.nix`:
+```
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+
+  buildInputs = with pkgs; [
+    sl
+    wget
+  ];
+}
+```
+1.2 if you run `nix-shell` from the directory where `shell.nix` exists, you should be dropped into a new shell and now have `sl` and `wget` binaries which you can test by running
+2. Run `poetry update`
+3. Run `poetry shell` inside `agent/agent`
+4. ??? (e.g. `python <...>`)
+5. PROFIT!11!!!
+
+
+## Running it
+Set `OPENAI_API_KEY` environment varibale if accessing models by OpenAI.
 
 ## Organizational Loops
 
@@ -13,3 +40,8 @@ The Agent will be used in the future to generate microworlds, which represent pa
 ## Conclusion
 
 The Agent is a powerful tool for improving communication and collaboration among team members, generating valuable insights and data about organizations and their operations, and supporting the creation of safe and effective microworlds. By using prompts to initiate and record conversations with team members, the Agent helps establish a shared information context for organizations. By collecting and managing data, the Agent can output a work dependency graph to help team members better synthesize information about what the organization is, what others within the organization are working on, and how all of these elements compose together.
+
+## Appendix
+### Reproducibility
+`nix` and `poetry` allow [packaging for serverless execution](https://github.com/bananaml/serverless-template) with reliable system, package, and other application dependencies like Secrets correctly derived for individual `agent` runtime environment.
+>>>>>>> d897d47 (0.100)

--- a/README.md
+++ b/README.md
@@ -44,4 +44,3 @@ The Agent is a powerful tool for improving communication and collaboration among
 ## Appendix
 ### Reproducibility
 `nix` and `poetry` allow [packaging for serverless execution](https://github.com/bananaml/serverless-template) with reliable system, package, and other application dependencies like Secrets correctly derived for individual `agent` runtime environment.
->>>>>>> d897d47 (0.100)


### PR DESCRIPTION
Instructions make it clear that `nix` needs to be checked.

Why?

It replaces many disparate package management systems for many languages, and Linux system libraries etc. (where traditionally operating system package manager would be used), or Anaconda / Node, with _one principled approach_ that seeks to precisely specify every antecedent -- no matter whether OS or ecosystem -- with a recursively hashed derivation from a tree of dependencies.


Better summarized here: https://shareg.pt/2QaIZcB


Dockerfile approach: Write instructions to build an image. Allows for more flexibility, but less reproducible.

Nix approach: Use declarative language to define dependencies and configuration. Provides reproducible builds and integrates well with Nix package manager.


